### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   rust-build:
     name: Rust Build


### PR DESCRIPTION
Potential fix for [https://github.com/local-first-from-scratch/origami/security/code-scanning/13](https://github.com/local-first-from-scratch/origami/security/code-scanning/13)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow and will explicitly set the `contents` permission to `read`. This is sufficient for the current workflow, as none of the jobs require write access to the repository or other elevated permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
